### PR TITLE
Fix bug "XML parse error in ATOM and RSS feed if link contains special characters".

### DIFF
--- a/theme/atom.xml.erb
+++ b/theme/atom.xml.erb
@@ -14,8 +14,8 @@
 %>
   <entry xml:lang="en">
     <title type="html" xml:lang="en"><%= CGI.escapeHTML(item.feed.title) %>: <%= CGI.escapeHTML(item.title) %></title>
-    <link href="<%= item.url %>"/>
-    <id><%= item.guid %></id>
+    <link href="<%= CGI.escapeHTML(item.url) %>"/>
+    <id><%= CGI.escapeHTML(item.guid) %></id>
     <updated><%= item.published.to_datetime.rfc3339 %></updated>
     <content type="html" xml:lang="en"><% if item.content %>
     <%= CGI.escapeHTML(item.content) %>

--- a/theme/rss.xml.erb
+++ b/theme/rss.xml.erb
@@ -13,8 +13,8 @@
 %>
 <item>
   <title><%= CGI.escapeHTML(item.title) %></title>
-  <guid><%= item.guid %></guid>
-  <link><%= item.url %></link>
+  <guid><%= CGI.escapeHTML(item.guid) %></guid>
+  <link><%= CGI.escapeHTML(item.url) %></link>
   <description><% if item.content %>
     <%= CGI.escapeHTML(item.content) %>
   <% elsif item.summary %>


### PR DESCRIPTION
Link to bug:
[XML parse error in ATOM and RSS feed if link contains special characters](https://github.com/gravitystorm/blogs.osm.org/issues/52)